### PR TITLE
Cert support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 # Debloat
 Debloat is a GUI and CLI tool to remove excess garbage from bloated executables.
 
-By excess garbage, I mean 100 - 800 MB of junk bytes added to a binary to keep it from going into a sandbox.
+By excess garbage, I mean 100 - 800 MB of junk bytes added to a binary to keep it from going into a sandbox. This method of adding junk is called "inflating" or "pumping" a binary. Debloat currently handles the 10 most common inflation tactics.
 
-Being built with Python, the code and logic is easily accessible for others to take the concepts and apply them to their own tools. The program can be compiled for Windows, MacOS, Linux. The GUI removes any need for remembering commandline options and reading through CLI manuals: it is intended to be as simple as possible. The logic within the program handles the different use cases automatically.
+Being built with Python, the application can easily be leveraged in other workflows. Currently, debloat is used by [CCCS's AssemblyLine](https://www.cyber.gc.ca/en/tools-services/assemblyline) and [CERT Polska's MWDB](https://github.com/CERT-Polska/karton-archive-extractor).
+
+ The program can be compiled for Windows, MacOS, Linux. The GUI and CLI have minimal options: it is intended to be as simple as possible and the logic within the program handles the different use cases automatically.
 
 Compiled binaries have already been included in the [Releases](https://github.com/Squiblydoo/debloat/releases/).
 
@@ -31,7 +33,7 @@ The gui can also be launched from the CLI using the command `debloat-gui`.
 
 ## Does it always work?
 Not yet.
-My unscientific guess is that it should work for every 7 of 8 binaries. There are specific usecases I know where it does not work and I am working to implement solutions for those usecases. 
+My unscientific guess is that it should work for every 9 of 10 binaries. There are specific usecases I know where it does not work and I am working to implement solutions for those usecases. 
 
 In previous versions, `debloat` could accidentally remove too much of the binary. That is no longer the case unless you use the "--last-ditch" switch. If you ever need this switch, consider sharing the sample for additional analysis. This option has now been added to the GUI. Functionally, what the function does is it will remove the whole overlay, if there is one. In some cases this is necessary as no pattern for the junk was found---this is most commonly the case in samples that do not compress well.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+1.5.6
+- Cert Support
+	- Added support in both CLI and GUI to preserve the authenticode certificate.
+		- Authenticode certificate is removed by default because the certificate becomes invalid. When it becomes invalid it becomes unclear whether the certificate was always invalid or not.
+- Bug Fix
+	- A result code was missing which could cause problems in processing that looked for a result code.
+
 1.5.5
 - General Improvements
 	- Added functionality to print debloat version/ added to GUI UI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debloat"
-version = "1.5.5"
+version = "1.5.6"
 authors = [
   { name="Squiblydoo", email="Squiblydoo@pm.me" },
 ]

--- a/src/debloat/gui.py
+++ b/src/debloat/gui.py
@@ -42,6 +42,12 @@ class MainWindow(TkinterDnD.Tk):
                                          variable=self.unsafe_processing)
         self.unsafe_checkbox.pack()
 
+        self.cert_preservation = BooleanVar(value=False)
+        self.cert_checkbox = Checkbutton(self, 
+                                        text="Preserve Cert. Cert will be invalid but informational.",
+                                        variable=self.cert_preservation)
+        self.cert_checkbox.pack()
+
         
 
         # Define Scrollbox for output of program.
@@ -90,6 +96,7 @@ with an executable. Maybe it needs unzipped?''')
 
         result_code = debloat.processor.process_pe(pe,  out_path, 
                                      self.unsafe_processing.get(), 
+                                     self.cert_preservation.get(),
                    log_message=self.output_scrollbox_handler,
                    beginning_file_size=file_size)
         self.output_scrollbox_handler("Tactic identified: " , RESULT_CODES.get(result_code) +"\n")

--- a/src/debloat/main.py
+++ b/src/debloat/main.py
@@ -24,6 +24,13 @@ def main() -> int:
     whole PE Overlay as a last resort if no smarter method works.
                             """,
                         action='store_true', default=False)
+    parser.add_argument("-c", "--cert", dest="cert_preservation", 
+                        help="""
+    Preserve the certificate on the end of the file if there is a certificate.
+    The certificate will no longer be valid.""",
+                        action='store_true',
+                        required=False,
+                        default=False)
     parser.add_argument("-v", "--version", action='version', version='debloat version ' + DEBLOAT_VERSION, help="Prints program version")
     args = parser.parse_args()
 
@@ -49,6 +56,7 @@ Maybe it needs unzipped?'''
     result_code = debloat.processor.process_pe(pe, 
                         out_path=str(out_path), 
                         last_ditch_processing=args.last_ditch_processing,
+                        cert_preservation=args.cert_preservation,
                         log_message=print,
                         beginning_file_size=file_size
                         )

--- a/src/debloat/performanceTest.py
+++ b/src/debloat/performanceTest.py
@@ -26,7 +26,7 @@ args = argparser.parse_args()
 def process_samples(sample, directory):
     file_size=os.path.getsize(args.directory +"/"+ sample)
     setup = f"import pefile; import debloat; filename = '{args.directory}/{sample}'; "
-    code = f"binary = pefile.PE(filename, fast_load=True); result= debloat.processor.process_pe(binary, filename + '.patched', last_ditch_processing=False, log_message=lambda *args, **kwargs: None, beginning_file_size={file_size}); print(result, end=' ')"
+    code = f"binary = pefile.PE(filename, fast_load=True); result= debloat.processor.process_pe(binary, filename + '.patched', last_ditch_processing=False, cert_preservation=True, log_message=lambda *args, **kwargs: None, beginning_file_size={file_size}); print(result, end=' ')"
 
     if args.mem:
         mem_profiler(setup, code, file_size, sample, directory)


### PR DESCRIPTION
This branch adds a capability to maintain the certificate on the executable.
By default, the certificate will be removed due to becoming invalid and to reduce confusion regarding whether the cert was valid or not to begin with.

Both the CLI and GUI have options for maintaining the certificate.