### PR TITLE
Always return result_code from check_section_compression

### DIFF
--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -398,7 +398,7 @@ The compression ratio of ''' + biggest_section.Name.decode() + ''' is indicative
             if delta_last_non_junk > original_section_size:
                 log_message("Section was not able to be reduced.")
                 result_code = 0
-                return result
+                return result, result_code
             data_to_delete.append((biggest_section.PointerToRawData + delta_last_non_junk, biggest_section_end))
             
             section_bytes_to_remove = original_section_size - delta_last_non_junk


### PR DESCRIPTION
This is related to issue #32. The return statement was not modified to include the new value.