### PR TITLE
Always return values from check_section_compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The gui can also be launched from the CLI using the command `debloat-gui`.
 
 ## Does it always work?
 Not yet.
-My unscientific guess is that it should work for every 9 of 10 binaries. There are specific usecases I know where it does not work and I am working to implement solutions for those usecases. 
+Based on my recent analysis, debloat is able to [remove junk files 97.8% of the time](https://x.com/SquiblydooBlog/status/1795419380991291424) from bloated files.
 
 In previous versions, `debloat` could accidentally remove too much of the binary. That is no longer the case unless you use the "--last-ditch" switch. If you ever need this switch, consider sharing the sample for additional analysis. This option has now been added to the GUI. Functionally, what the function does is it will remove the whole overlay, if there is one. In some cases this is necessary as no pattern for the junk was found---this is most commonly the case in samples that do not compress well.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+1.5.6.2
+- Bug Fix
+	- Not all possible paths returned a result code. An additional result code was added.
+
+1.5.6.1
+- Bug Fix
+	- Added the result code for real this time.
+
 1.5.6
 - Cert Support
 	- Added support in both CLI and GUI to preserve the authenticode certificate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debloat"
-version = "1.5.6"
+version = "1.5.6.2"
 authors = [
   { name="Squiblydoo", email="Squiblydoo@pm.me" },
 ]

--- a/src/debloat/performanceTest.py
+++ b/src/debloat/performanceTest.py
@@ -26,7 +26,7 @@ args = argparser.parse_args()
 def process_samples(sample, directory):
     file_size=os.path.getsize(args.directory +"/"+ sample)
     setup = f"import pefile; import debloat; filename = '{args.directory}/{sample}'; "
-    code = f"binary = pefile.PE(filename, fast_load=True); result= debloat.processor.process_pe(binary, filename + '.patched', last_ditch_processing=False, cert_preservation=True, log_message=lambda *args, **kwargs: None, beginning_file_size={file_size}); print(result, end=' ')"
+    code = f"binary = pefile.PE(filename, fast_load=True); result= debloat.processor.process_pe(binary, filename + '.patched', last_ditch_processing=False, cert_preservation=False, log_message=lambda *args, **kwargs: None, beginning_file_size={file_size}); print(result, end=' ')"
 
     if args.mem:
         mem_profiler(setup, code, file_size, sample, directory)

--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -22,7 +22,7 @@ from typing import Generator, Iterable, Optional
 import debloat.utilities.nsisParser as nsisParser
 import debloat.utilities.rsrc as rsrc
 
-DEBLOAT_VERSION = "1.5.5"
+DEBLOAT_VERSION = "1.5.6.2"
 
 RESULT_CODES = {
     0: "No Solution found.",
@@ -359,10 +359,7 @@ def check_section_compression(pe: pefile.PE, data_to_delete: List,
             log_message("Section: "  + section_name, end="\t", flush=True)
             log_message(" Compression Ratio: " + str(round(section_compression_ratio, 2)) +"%", end="\t",flush=True)
             log_message("Size of section: " + readable_size(section.SizeOfRawData) +".",flush=True)
-            if biggest_section is None:
-                biggest_section = section
-                biggest_uncompressed = section_compression_ratio
-            elif section.SizeOfRawData > biggest_section.SizeOfRawData:
+            if biggest_section is None or section.SizeOfRawData > biggest_section.SizeOfRawData:
                 biggest_section = section
                 biggest_uncompressed = section_compression_ratio
         # Handle specific bloated sections

--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -383,7 +383,7 @@ Bloat was located in the resource section. Removing bloat..
                 log_message('''
 Bloat was detected in the text section. Bloat is likely in a .NET Resource
 This use case cannot be processed at this time. ''')
-            result_code = 0 # No solution 
+            result_code = 0 # No solution
             return result, result_code
         if biggest_uncompressed > 3000:
             log_message('''
@@ -407,6 +407,10 @@ The compression ratio of ''' + biggest_section.Name.decode() + ''' is indicative
             log_message("Bloated section reduced.")
             result_code = 7 # Bloated PE section
             return result, result_code
+
+        # If no bloat was found, return an expected return value
+        result_code = 0 # No solution
+        return result, result_code
 
 def find_chunk_start(targeted_regex, chunk_start, original_size_with_junk, bloated_content: memoryview, step):
     bloated_content_len = len(bloated_content)


### PR DESCRIPTION
I was wondering if this is what an unbloated file should be returning, so that running debloat on non-bloated files does not error out.