### PR TITLE
Bug fix plus enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/debloat/.vscode
 src/debloat/samples
 src/debloat/UnSorted_samples
 src/debloat/Old_Sample_Set
+src/debloat/TODO.md

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,16 @@
+1.5.6.3
+- Bug Fixes
+	- Modified NSIS Parser to address issue identified in the implementation. More details here: https://github.com/binref/refinery/issues/49
+		- TLDR, NSIS Installers with the properly of uncompressed data was not previously accounted for due to lack of examples. They now are accounted for.
+	- Modified compression check in bloated overlay analysis
+		- previous compression check was erroneous and worked only based on miracles.
+- Improvements
+	- Modified trimming threshold: 0.05 -> 0.15
+		- New trimming threshold allows for lower compressed junk.
+		- New trimming threshold removes more junk without being too aggressive.
+- Known issue
+	- The certificate preservation option does not preserve the certificate in all use-cases, particularly cases where junk is in the overlay.
+
 1.5.6.2
 - Bug Fix
 	- Not all possible paths returned a result code. An additional result code was added.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debloat"
-version = "1.5.6.2"
+version = "1.5.6.3"
 authors = [
   { name="Squiblydoo", email="Squiblydoo@pm.me" },
 ]


### PR DESCRIPTION
Fixed a bug in the NSIS Extractor. Changed threshold for trimming to account for more use cases and trim excess junk.

Ran performance test. Results are comparable to 1.5.6.2. All use cases complete as expected. Some tactics finish with the same "tactic" but that is expected. The no solution cases are expected. Tactic-9 fails fast as expected. Patched samples were manually inspected and compared against other patched samples. 
```
7 7 7 7 tactic-7 1.264GB 1.287GB [12.51, 12.45, 12.45]
0 0 0 0 tactic-8 307.925MB 308.269MB [2.29, 2.31, 2.32]
0 0 0 0 tactic-9 734.451MB 734.831MB [0.2, 0.2, 0.2]
3 3 3 3 tactic-10 762.939MB 794.630MB [3.31, 3.32, 3.42]
3 3 3 3 tactic-13 1.168GB 1.364GB [11.66, 11.32, 11.37]
0 0 0 0 tactic-11 307.925MB 308.269MB [2.33, 2.34, 2.32]
3 3 3 3 tactic-3 726.000MB 744.873MB [3.25, 3.27, 3.17]
2 2 2 2 tactic-2 762.939MB 826.202MB [2.73, 2.95, 2.78]
12 12 12 12 tactic-12 320.149MB 341.778MB [4.66, 4.64, 4.64]
6 6 6 6 tactic-6 300.348MB 308.884MB [4.39, 4.38, 4.36]
1 1 1 1 tactic-1 738.980MB 740.680MB [0.0, 0.0, 0.0]
4 4 4 4 tactic-4 439.726MB 468.639MB [2.38, 2.39, 2.45]
```