### PR TITLE
Bug fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 - Bug Fixes
 	- Fixed logic that could incorrectly flag .text sections as suspicious.
 	- Handled rare error that could occur in updating offsets.
+	- Certificate preservation now works reliably for all use-cases. 
 
 1.5.6.3
 - Bug Fixes

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+1.5.6.4
+- Bug Fixes
+	- Fixed logic that could incorrectly flag .text sections as suspicious.
+	- Handled rare error that could occur in updating offsets.
+
 1.5.6.3
 - Bug Fixes
 	- Modified NSIS Parser to address issue identified in the implementation. More details here: https://github.com/binref/refinery/issues/49

--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -503,7 +503,7 @@ def process_pe(pe: pefile.PE, out_path: str, last_ditch_processing: bool,
     if cert_preservation == True:
         cert = [(signature_address, signature_address + signature_size)]
         certData = memoryview(pe.__data__)[signature_address:signature_address + signature_size]
-        data_to_delete = []
+        data_to_delete = [(signature_address, signature_address + signature_size)]
     else:
         if signature_size > 0:
             log_message("""A certificate is being removed from this file.\n-To preserve the certificate use the Cert Preservation option.""")
@@ -592,6 +592,7 @@ Twitter: @SquiblydooBlog.
             start = slice_end
         pe_data += bytearray(pe.__data__[start:beginning_file_size])
         if cert_preservation == True and signature_size > 0:
+            pe_data += certData
             pe.OPTIONAL_HEADER.DATA_DIRECTORY[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_SECURITY']].VirtualAddress = len(pe_data) - signature_size
 
         pe.__data__ = pe_data


### PR DESCRIPTION
In this branch, we did the following:
1.5.6.4
- Bug Fixes
	- Fixed logic that could incorrectly flag .text sections as suspicious.
	- Handled rare error that could occur in updating offsets.
	- Certificate preservation now works reliably for all use-cases. 

These bugfixes were thanks to our automation in finding samples where debloat failed. It worked most of the time, but these small bugs caused issues in these few cases.
Changes are minor with no significant change impacting performance.