### PR TITLE
Reverted change

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+1.5.6.5
+- Bug Fix
+	- Inadvertently changed "sample_compression" limit, thought it'd be OK, but it actually causes this check's main purpose to fail (that is, failing quickly when needed). Got some new ideas out of it though.
+
 1.5.6.4
 - Bug Fixes
 	- Fixed logic that could incorrectly flag .text sections as suspicious.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debloat"
-version = "1.5.6.3"
+version = "1.5.6.5"
 authors = [
   { name="Squiblydoo", email="Squiblydoo@pm.me" },
 ]

--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -22,7 +22,7 @@ from typing import Generator, Iterable, Optional
 import debloat.utilities.nsisParser as nsisParser
 import debloat.utilities.rsrc as rsrc
 
-DEBLOAT_VERSION = "1.5.6.4"
+DEBLOAT_VERSION = "1.5.6.5"
 
 RESULT_CODES = {
     0: "No Solution found.",
@@ -535,7 +535,7 @@ def process_pe(pe: pefile.PE, out_path: str, last_ditch_processing: bool,
             overlay_compression_sample = get_compressed_size(memoryview(overlay)[-2000:], 2000)
             sample_compression = beginning_file_size / overlay_compression_sample 
             file_size_wo_overlay = len(memoryview(pe.__data__)[:last_section.PointerToRawData + last_section.SizeOfRawData])
-            if sample_compression > 350000:
+            if sample_compression > 400000:
                 required_data_from_overlay, result_code = trim_junk(pe, overlay, beginning_file_size)
                 end_of_real_data = file_size_wo_overlay + required_data_from_overlay
                 data_to_delete.append(((file_size_wo_overlay + required_data_from_overlay), beginning_file_size ))


### PR DESCRIPTION
Reverted compression check and learned some lessons along the way.
The sample_compression check was changed during some previous testing, but it allowed a critical test tactic to take 22seconds to fail instead of the failing fast of 2seconds or so.

This taught me the need to either:
1) Not merge changes before coffee
or 
2) Put in more automated tests, databases, etc to tract statistics instead of eye-balling it.

2 is more likely.