### PR TITLE
Improve NSItem object equality check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ src/debloat/samples
 src/debloat/UnSorted_samples
 src/debloat/Old_Sample_Set
 src/debloat/TODO.md
+src/debloat/unsolved
+src/debloat/temp

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+1.5.6.6
+- Bug Fix
+	- Patches bug in Result-Code 4 where an excess could be removed. 
+		- This was due to a miscalculation. In these instances, the "dynamic trim" and "refinery trim" methods were essentially being applied to the same data, then calculating an excess of junk.
+	- The check for duplicate items in an NSIS Installer has been improved.
+		- Previous check looked for item at the same offset; this version checks to see that all features are the same. 
+
 1.5.6.5
 - Bug Fix
 	- Inadvertently changed "sample_compression" limit, thought it'd be OK, but it actually causes this check's main purpose to fail (that is, failing quickly when needed). Got some new ideas out of it though.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debloat"
-version = "1.5.6.5"
+version = "1.5.6.6"
 authors = [
   { name="Squiblydoo", email="Squiblydoo@pm.me" },
 ]

--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -22,7 +22,7 @@ from typing import Generator, Iterable, Optional
 import debloat.utilities.nsisParser as nsisParser
 import debloat.utilities.rsrc as rsrc
 
-DEBLOAT_VERSION = "1.5.6.5"
+DEBLOAT_VERSION = "1.5.6.6"
 
 RESULT_CODES = {
     0: "No Solution found.",
@@ -38,7 +38,9 @@ RESULT_CODES = {
     10: "High compression with bytes at end.",
     11: ".NET Single File with junk",
     12: "Packed file with bloated section",
-    13: "Random overlay with high compression"
+    13: "Random overlay with high compression",
+    14: "Junk interspersed with data",
+    15: "VMProtected junk",
 }
 
 
@@ -477,6 +479,7 @@ def trim_junk(pe: pefile.PE, bloated_content: memoryview,
         # repeated bytes. We use refinery_trim for efficiency.
         if junk_to_remove * 2 < original_size_with_junk / 2:
             delta_last_non_junk = refinery_strip(bloated_content, alignment)
+            junk_to_remove = 0 # Reset junk_to_remove because Refinery Strip will remove it.
             result_code = 4 # Sets of repeated bytes in overlay.
         else:
             result_code = 2 # Single repeated byte in overlay

--- a/src/debloat/utilities/nsisParser.py
+++ b/src/debloat/utilities/nsisParser.py
@@ -11,7 +11,6 @@ import itertools
 import re
 import io
 import dataclasses
-import ntpath
 
 import zlib
 import lzma
@@ -464,7 +463,7 @@ class NSItem:
             and self.estimated_size == other.estimated_size
             and self.dictionary_size == other.dictionary_size
             and self.patch_size == other.patch_size
-            and ntpath.join(self.prefix or "", self.name) == ntpath.join(other.prefix or "", other.name)
+            and self.path == other.path
         )
 
 

--- a/src/debloat/utilities/nsisParser.py
+++ b/src/debloat/utilities/nsisParser.py
@@ -11,6 +11,7 @@ import itertools
 import re
 import io
 import dataclasses
+import ntpath
 
 import zlib
 import lzma
@@ -448,6 +449,23 @@ class NSItem:
     
     def __str__(self) -> str:
         return self.name
+
+    def __eq__(self, other) -> bool:
+        if not other or not isinstance(other, self.__class__):
+            return False
+        return (
+            self.offset == other.offset
+            and self.mtime == other.mtime
+            and self.is_compressed == other.is_compressed
+            and self.is_uninstaller == other.is_uninstaller
+            and self.attributes == other.attributes
+            and self.size == other.size
+            and self.compressed_size == other.compressed_size
+            and self.estimated_size == other.estimated_size
+            and self.dictionary_size == other.dictionary_size
+            and self.patch_size == other.patch_size
+            and ntpath.join(self.prefix or "", self.name) == ntpath.join(other.prefix or "", other.name)
+        )
 
 
 class NSHeader(Struct):


### PR DESCRIPTION
Modification of the NSItem equality function that can cover the case raised in #42.
Two objects are found with the same offset `1785955`/`0x001b4063` and path `$PLUGINSDIR\installer-helper.dll`. All of their item in the NSItem class are identical except the name and the prefix. There is name:`$PLUGINSDIR\installer-helper.dll` and no prefix (`None`) for one, and name:`installer-helper.dll` with prefix:`$PLUGINSDIR` for the other, which explains the identical path and key of `(item.path, item.offset)` in the  items directory. The two items have different instruction.arguments (`[83886224, 97, 1785955, 2478026752, 31114788, 4294967259]` vs `[83886225, 94, 1785955, 4294967295, 4294967295, 4294967259]`.

I used the ntpath library to generate combination of prefix and name before realizing I could use `self.path == other.path`. I can change it quickly and remove the import if we want to use this solution.