### PR TITLE
Escaping non-unicode section names

### DIFF
--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -355,7 +355,7 @@ def check_section_compression(pe: pefile.PE, data_to_delete: List,
         biggest_uncompressed = int
         result = ""
         for section in pe.sections:
-            section_name = section.Name.decode()
+            section_name = section.Name.decode("utf8", errors="backslashreplace")
             compressed_section_size = get_compressed_size(
                 memoryview(pe.__data__)[section.PointerToRawData : section.PointerToRawData+section.SizeOfRawData],
                 section.SizeOfRawData
@@ -368,7 +368,7 @@ def check_section_compression(pe: pefile.PE, data_to_delete: List,
                 biggest_section = section
                 biggest_uncompressed = section_compression_ratio
         # Handle specific bloated sections
-        if biggest_section.Name.decode() == ".rsrc\x00\x00\x00":
+        if biggest_section.Name.decode("utf8", errors="backslashreplace") == ".rsrc\x00\x00\x00":
             # Get biggest resource or resources and drop them from the
             # Resource table
             log_message('''
@@ -378,7 +378,7 @@ Bloat was located in the resource section. Removing bloat..
             result_code = 6 # Bloated resource
             return result, result_code
 
-        elif biggest_section.Name.decode() == ".text\x00\x00\x00" and biggest_uncompressed > 3000:
+        elif biggest_section.Name.decode("utf8", errors="backslashreplace") == ".text\x00\x00\x00" and biggest_uncompressed > 3000:
             # Data stored in the .text section is often a .NET Resource. The following checks
             # to confirm it is .NET and then drops the resources.
             if pe.OPTIONAL_HEADER.DATA_DIRECTORY[14].Size:
@@ -389,7 +389,7 @@ This use case cannot be processed at this time. ''')
             return result, result_code
         if biggest_uncompressed > 3000:
             log_message('''
-The compression ratio of ''' + biggest_section.Name.decode() + ''' is indicative of a bloated section.
+The compression ratio of ''' + biggest_section.Name.decode("utf8", errors="backslashreplace") + ''' is indicative of a bloated section.
 ''', end="", flush=True)
             # Get the size of the section.
             biggest_section_end = biggest_section.PointerToRawData + biggest_section.SizeOfRawData


### PR DESCRIPTION
I found a few samples like [this one](https://bazaar.abuse.ch/sample/1b7babe5fde91a44f8488aef2873078cc9f4ac5810625bcd6c271cf13e8d6145) which are causing this error in debloat

```python
>>> import debloat.processor
>>> import pefile
>>> import os
>>> file_path = "1b7babe5fde91a44f8488aef2873078cc9f4ac5810625bcd6c271cf13e8d6145"
>>> binary = pefile.PE(file_path, fast_load=True)
>>> file_size = os.path.getsize(file_path)
>>> debloat.processor.process_pe(binary, out_path="out", last_ditch_processing=False, cert_preservation=True, log_message=print, beginning_file_size=file_size)
Section: .text   Compression Ratio: 250.98%     Size of section: 1024 bytes.
Section: .rdata  Compression Ratio: 204.8%      Size of section: 512 bytes.
Section: .data   Compression Ratio: 116.04%     Size of section: 38.5 MB.
Section: .rsrc   Compression Ratio: 261.76%     Size of section: 266.0 KB.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../debloat/processor.py", line 578, in process_pe
    result, result_code = check_section_compression(pe, data_to_delete, log_message=log_message)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../debloat/processor.py", line 358, in check_section_compression
    section_name = section.Name.decode()
                   ^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9b in position 0: invalid start byte
```

After this small fix, they will show the following:
```python
>>> file_path = "1b7babe5fde91a44f8488aef2873078cc9f4ac5810625bcd6c271cf13e8d6145"
>>> file_size = os.path.getsize(file_path)
>>> binary = pefile.PE(file_path, fast_load=True)
>>> debloat.processor.process_pe(binary, out_path="out", last_ditch_processing=False, cert_preservation=True, log_message=print, beginning_file_size=file_size)
Section: .text   Compression Ratio: 250.98%     Size of section: 1024 bytes.
Section: .rdata  Compression Ratio: 204.8%      Size of section: 512 bytes.
Section: .data   Compression Ratio: 116.04%     Size of section: 38.5 MB.
Section: .rsrc   Compression Ratio: 261.76%     Size of section: 266.0 KB.
Section: \x9b\xa3\xff\xa3u       Compression Ratio: 128.63%     Size of section: 16.5 KB.

No automated method for reducing the size worked. Please consider sharing the
sample for additional analysis.
Email: Squiblydoo@pm.me
Twitter: @SquiblydooBlog.

0
```

I can change it to not specify the encoding if preferred, and/or a different error handling.
Thank you!