### PR TITLE
Fixes error handling.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+1.6.2
+- Fixes bug in adjust_offsets method that impacted tactic-7. Bug was introduced in 1.5.6.4 as a bad attempt at error handling.
+	- When adjusting offsets, it was possible for an error to be thrown because adjusting the offset would set it to an invalid value. However, this would happen because the value was invalid to begin with. The incorrect value was being improperly handled. I'm not 100% sure that I have it correct, but the new change works as expected.
+
 1.6.1
 - Fixes legacy bug that could result in failure to identify NSIS installers.
 	- In previous builds, we only checked a small window for the NSIS header. That window has been increased.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debloat"
-version = "1.6.0"
+version = "1.6.2"
 authors = [
   { name="Squiblydoo", email="Squiblydoo@pm.me" },
 ]

--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -22,7 +22,7 @@ from typing import Generator, Iterable, Optional
 import debloat.utilities.nsisParser as nsisParser
 import debloat.utilities.rsrc as rsrc
 
-DEBLOAT_VERSION = "1.6.0"
+DEBLOAT_VERSION = "1.6.2"
 
 RESULT_CODES = {
     0: "No Solution found.",
@@ -235,7 +235,6 @@ def adjust_offsets(pe: pefile.PE, gap_offset: int, gap_size: int):
                 'PointerToRawData',
             ))
         except Exception as e:
-            remove.append(index)
             continue
 
         for attribute in (


### PR DESCRIPTION
1.6.2
- Fixes bug in adjust_offsets method that impacted tactic-7. Bug was introduced in 1.5.6.4 as a bad attempt at error handling.
	- When adjusting offsets, it was possible for an error to be thrown because adjusting the offset would set it to an invalid value. However, this would happen because the value was invalid to begin with. The incorrect value was being improperly handled. I'm not 100% sure that I have it correct, but the new change works as expected.