### PR TITLE
Extend check for removal of data

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+1.6.4
+- Added an additional check to identify the Code-signing signature anomaly. This check previously exited if the anomaly was found but it did not check to determine if enough of the file was removed. Now a size check has been added in order to determine if additional processing is required. 
+
 1.6.3
 - Fixes bug where debloat failed to handle malformed files. 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debloat"
-version = "1.6.3"
+version = "1.6.4"
 authors = [
   { name="Squiblydoo", email="Squiblydoo@pm.me" },
 ]

--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -22,7 +22,7 @@ from typing import Generator, Iterable, Optional
 import debloat.utilities.nsisParser as nsisParser
 import debloat.utilities.rsrc as rsrc
 
-DEBLOAT_VERSION = "1.6.3"
+DEBLOAT_VERSION = "1.6.4"
 
 RESULT_CODES = {
     0: "No Solution found.",

--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -530,7 +530,7 @@ def process_pe(pe: pefile.PE, out_path: str, last_ditch_processing: bool,
                                                         signature_size,
                                                         beginning_file_size,
                                                         data_to_delete)
-    if signature_abnormality is True:
+    if signature_abnormality is True and sum(slice_end-slice_start for slice_start, slice_end in data_to_delete) >= (beginning_file_size * 0.1):
         pass
     # Handle Overlays: this includes packers and overlays which are completely junk
     elif pe.get_overlay_data_start_offset() and signature_size < len(pe.__data__) - pe.get_overlay_data_start_offset():


### PR DESCRIPTION
Signature anomaly only checked for the removal of data but not the amount of data that was removed. This change will now check to ensure that greater than 10 percent was removed, it will then continue normal processing.