### PR TITLE
Update NSIS functionality

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+1.6.5
+- Fixed bug introduced in 1.6.1 which consistently resulted in failure to parse NSIS installers.
+- Updated NSIS extraction script to include new functionality from BinaryRefinery
+- Removed use of ByteString which was removed in python3.14
+
 1.6.4
 - Added an additional check to identify the Code-signing signature anomaly. This check previously exited if the anomaly was found but it did not check to determine if enough of the file was removed. Now a size check has been added in order to determine if additional processing is required. 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "debloat"
-version = "1.6.4"
+version = "1.6.5"
 authors = [
   { name="Squiblydoo", email="Squiblydoo@pm.me" },
 ]

--- a/src/debloat/processor.py
+++ b/src/debloat/processor.py
@@ -22,7 +22,7 @@ from typing import Generator, Iterable, Optional
 import debloat.utilities.nsisParser as nsisParser
 import debloat.utilities.rsrc as rsrc
 
-DEBLOAT_VERSION = "1.6.4"
+DEBLOAT_VERSION = "1.6.5"
 
 RESULT_CODES = {
     0: "No Solution found.",


### PR DESCRIPTION
1.6.5
- Fixed bug introduced in 1.6.1 which consistently resulted in failure to parse NSIS installers.
- Updated NSIS extraction script to include new functionality from BinaryRefinery
- Removed use of ByteString which was removed in python3.14