### PR TITLE
Move logging.basicConfig to main() methods

### DIFF
--- a/src/debloat/gui.py
+++ b/src/debloat/gui.py
@@ -1,4 +1,5 @@
 """This file handles all GUI components."""
+import logging
 import os
 import time
 from pathlib import Path 
@@ -105,6 +106,7 @@ with an executable. Maybe it needs unzipped?''')
         self.clear_pathbox()
 
 def main() -> None:
+    logging.basicConfig(level=logging.WARN)
     root = MainWindow()
     root.mainloop()
 

--- a/src/debloat/main.py
+++ b/src/debloat/main.py
@@ -1,4 +1,5 @@
 """This file handles passing the CLI arguments into the processor"""
+import logging
 import os
 import sys
 from pathlib import Path
@@ -10,6 +11,7 @@ from debloat.processor import RESULT_CODES
 
 
 def main() -> int:
+    logging.basicConfig(level=logging.WARN)
     parser = argparse.ArgumentParser()
     parser.add_argument("executable", 
                         help="Path to the executable to be debloated",

--- a/src/debloat/utilities/nsisParser.py
+++ b/src/debloat/utilities/nsisParser.py
@@ -32,8 +32,6 @@ from typing import (
     Dict,
     Type)
 
-logging.basicConfig(level=logging.WARN)
-
 class UnpackResult:
 
     def get_data(self) -> Union[bytes, bytearray, memoryview]:


### PR DESCRIPTION
Hello!

I noticed that `logging.basicConfig` is called at the time of the import, which prevents further `logging.basicConfig` calls to setup preferred logging configuration. I found it while debugging why [logging.basicConfig](https://github.com/CERT-Polska/karton-archive-extractor/blob/60cafee7c0d13d9dc9741db396d2596faa7dbdee/karton/archive_extractor/unpacker.py#L306) in `karton.archive_extractor.unpacker` doesn't work :smile: 

This PR moves logging setup from the top of the `debloat.utilities.nsisParser` to the top of the `main` methods.
